### PR TITLE
fix: ensure Alembic env imports app

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os
+import os, sys, pathlib
 from logging.config import fileConfig
 from sqlalchemy import engine_from_config, pool
 from alembic import context
@@ -12,8 +12,12 @@ config.set_main_option("sqlalchemy.url", db_url)
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-from app.db import Base  # noqa
-from app import models  # noqa
+# Ensure 'backend' root is on sys.path so `import app` works
+root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+
+from app.db import Base  # type: ignore # noqa: E402
+from app import models  # type: ignore # noqa: E402
 
 target_metadata = Base.metadata
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,5 +4,8 @@ SQLAlchemy==2.0.35
 psycopg==3.2.1
 alembic==1.13.2
 pydantic==2.8.2
-python-dotenv==1.0.1
+pydantic-settings==2.4.0
+email-validator==2.3.0
+python-multipart==0.0.9
 requests==2.32.3
+httpx==0.28.1


### PR DESCRIPTION
## Summary
- add backend root to sys.path in Alembic env so migrations can import app modules
- declare backend dependencies for settings and email validation

## Testing
- `python -m pytest -q`
- `curl -s http://localhost:8000/health`


------
https://chatgpt.com/codex/tasks/task_e_68bebe3b44948330a098d2acebfac1df