### PR TITLE
build: install httpx and email-validator

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,10 +21,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: orga
         options: >-
-          --health-cmd="pg_isready -U postgres -d orga" \
-          --health-interval=10s \
-          --health-timeout=5s \
-          --health-retries=10
+          --health-cmd="pg_isready -U postgres -d orga" --health-interval=10s --health-timeout=5s --health-retries=10
         ports:
           - 5432:5432
     env:
@@ -42,12 +39,13 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install fastapi==0.112.2 uvicorn[standard]==0.30.6 SQLAlchemy==2.0.35 \
-                     pydantic==2.8.2 pydantic-settings==2.4.0 psycopg[binary]==3.2.1 \
-                     alembic==1.13.2 python-multipart==0.0.9 pytest
+                     pydantic==2.8.2 pydantic-settings==2.4.0 email-validator==2.3.0 \
+                     psycopg[binary]==3.2.1 alembic==1.13.2 python-multipart==0.0.9 \
+                     httpx==0.28.1 pytest
       - name: Wait for Postgres
         run: |
           for i in {1..60}; do
-            pg_isready -h localhost -U postgres -d orga && break
+            (echo > /dev/tcp/127.0.0.1/5432) >/dev/null 2>&1 && break
             echo "waiting for postgres..."
             sleep 2
           done

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,10 +18,12 @@ RUN pip install --no-cache-dir \
     SQLAlchemy==2.0.35 \
     pydantic==2.8.2 \
     pydantic-settings==2.4.0 \
+    email-validator==2.3.0 \
     psycopg[binary]==3.2.1 \
     psycopg-binary==3.2.1 \
     alembic==1.13.2 \
-    python-multipart==0.0.9
+    python-multipart==0.0.9 \
+    httpx==0.28.1
 
 EXPOSE 8000
 CMD ["bash","-lc","./docker/entrypoint.sh"]


### PR DESCRIPTION
## Step
STEP_ID: STEP_02_Modele_de_donnees

## Goal
- fix backend CI by adding missing HTTP client dependencies and robust health checks

## Acceptance Criteria
- [x] backend workflow installs httpx and email-validator
- [x] Postgres health options rendered on a single line
- [x] local tests pass

## Deliverables
- Code: Dockerfile, backend GitHub Actions workflow
- Tests: `pytest`
- Docs: n/a
- Scripts: n/a

## Migrations
- DB: none
- Config: none
- Data: none

## Validation
- Local: `pytest -q`, `pwsh PS1/smoke.ps1`
- CI: `backend` job

## Impacts Infra/DevOps
- workflow waits on Postgres via /dev/tcp
- Docker image and CI install httpx + email-validator

## Rollback Plan
- revert commit `build: install httpx and email-validator`


------
https://chatgpt.com/codex/tasks/task_e_68bec6cede248330adc859865de9dfae