### PR TITLE
feat(dev): add Windows bootstrap and optional dev container profile

### DIFF
--- a/PS1/backend_tests.ps1
+++ b/PS1/backend_tests.ps1
@@ -1,3 +1,21 @@
+#!/usr/bin/env pwsh
 $ErrorActionPreference = "Stop"
-Write-Host "Running backend tests inside container..."
-docker compose exec -T api pytest -q
+
+# ensure venv
+if (-not (Test-Path ".venv")) { python -m venv .venv }
+. .\.venv\Scripts\Activate.ps1
+python -m pip install -U pip
+if (Test-Path "backend/requirements-dev.txt") {
+  pip install -r backend/requirements-dev.txt
+} else {
+  pip install pytest httpx
+}
+
+# Use sqlite by default for local tests
+if (-not $env:DATABASE_URL) { $env:DATABASE_URL = "sqlite:///./test.db" }
+
+Set-Location backend
+python -m pytest -q
+
+Write-Host "Tests OK" -ForegroundColor Green
+

--- a/PS1/dev_bootstrap.ps1
+++ b/PS1/dev_bootstrap.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env pwsh
+# Dev bootstrap: create .venv, install runtime+dev deps, run alembic, quick smoke.
+# Usage:
+#   pwsh -File PS1/dev_bootstrap.ps1 [-DatabaseUrl <URL>] [-Recreate]
+# Examples:
+#   pwsh -File PS1/dev_bootstrap.ps1
+#   pwsh -File PS1/dev_bootstrap.ps1 -DatabaseUrl "postgresql+psycopg://postgres:postgres@localhost:5432/orga"
+#   pwsh -File PS1/dev_bootstrap.ps1 -Recreate
+
+param(
+  [string]$DatabaseUrl,
+  [switch]$Recreate
+)
+
+$ErrorActionPreference = "Stop"
+
+# 1) venv
+if (-not (Test-Path ".venv")) { python -m venv .venv }
+. .\.venv\Scripts\Activate.ps1
+python -m pip install -U pip
+
+# 2) deps
+if (Test-Path "backend/requirements-dev.txt") {
+  pip install -r backend/requirements-dev.txt
+} else {
+  pip install fastapi==0.112.2 uvicorn[standard]==0.30.6 SQLAlchemy==2.0.35 `
+              pydantic==2.8.2 pydantic-settings==2.4.0 psycopg-binary==3.2.1 `
+              alembic==1.13.2 python-multipart==0.0.9 pytest httpx
+}
+
+# 3) DB URL (default to sqlite file)
+if (-not $DatabaseUrl) {
+  if ($env:DATABASE_URL) { $DatabaseUrl = $env:DATABASE_URL } else { $DatabaseUrl = "sqlite:///./dev_bootstrap.db" }
+}
+$env:DATABASE_URL = $DatabaseUrl
+
+# 4) Optional recreate sqlite file
+if ($Recreate -and $DatabaseUrl -like "sqlite*dev_bootstrap.db*") {
+  if (Test-Path "dev_bootstrap.db") { Remove-Item -Force dev_bootstrap.db }
+}
+
+# 5) Alembic migrate
+Set-Location backend
+alembic -c alembic.ini upgrade head
+
+# 6) Quick smoke (FastAPI app import + create a test client health)
+@"
+from fastapi.testclient import TestClient
+from app.main import app
+c = TestClient(app)
+r = c.get("/health")
+assert r.status_code == 200 and r.json().get("status") == "ok"
+print("smoke: /health OK")
+"@ | python -
+
+Write-Host "Dev bootstrap OK" -ForegroundColor Green
+
+# 7) Suggest next commands
+Write-Host "Next: pwsh -File PS1/backend_tests.ps1" -ForegroundColor Cyan
+

--- a/README.md
+++ b/README.md
@@ -60,3 +60,21 @@ Puis :
   - `pwsh -File PS1/seed.ps1`
   - `pwsh -File PS1/backend_tests.ps1`
   - `pwsh -File PS1/smoke.ps1`
+
+## Local dev bootstrap (Windows)
+
+- Bootstrap host env:
+```
+pwsh -File PS1/dev_bootstrap.ps1
+pwsh -File PS1/backend_tests.ps1
+```
+
+- Optional dev container (pytest inside image):
+```
+docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile dev up -d --build db api-dev
+
+# run tests inside container if needed
+
+$id = docker ps --filter "label=com.docker.compose.service=api-dev" -q | head -n1
+docker exec -it $id bash -lc "cd /app/backend && pytest -q"
+```

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app/backend
+COPY backend/ /app/backend/
+
+# Dev deps include pytest/httpx
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+EXPOSE 8000
+CMD ["bash","-lc","./docker/entrypoint.sh"]
+

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest==8.3.3
+httpx==0.27.2
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,11 +1,9 @@
 fastapi==0.112.2
 uvicorn[standard]==0.30.6
 SQLAlchemy==2.0.35
-psycopg==3.2.1
-alembic==1.13.2
 pydantic==2.8.2
 pydantic-settings==2.4.0
-email-validator==2.3.0
+psycopg[binary]==3.2.1
+alembic==1.13.2
 python-multipart==0.0.9
-requests==2.32.3
-httpx==0.28.1
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,25 @@
+services:
+  api-dev:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile.dev
+    environment:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@db:5432/orga
+      APP_ENV: docker
+      APP_DEBUG: "false"
+      PYTHONPATH: /app/backend:/app
+      ALEMBIC_CONFIG: /app/backend/alembic.ini
+    working_dir: /app/backend
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
+    command: ["/bin/bash","-lc","./docker/entrypoint.sh"]
+    ports:
+      - "8000:8000"
+    profiles: ["dev"]
+


### PR DESCRIPTION
## Summary
- add PowerShell bootstrap for venv setup and smoke tests on Windows
- refresh backend requirements and include dev deps
- provide optional dev Dockerfile and compose profile with pytest in image

## Testing
- `pip install -r backend/requirements-dev.txt`
- `pytest -q` *(fails: ConnectionRefusedError)*
- `pytest backend/tests -q` *(fails: KeyError: 'id')*

## Labels
- area:dev
- windows-first
- no-mock
- docs

------
https://chatgpt.com/codex/tasks/task_e_68beebb9a3c08330910bc327a7656f17