### PR TITLE
chore: update deps and scripts for email validation

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,16 +28,18 @@ jobs:
       DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/orga
       APP_ENV: ci
       APP_DEBUG: 'false'
+      PYTHONPATH: backend:.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install backend deps
+      - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install -r backend/requirements.txt
-          pip install pytest
+          pip install fastapi==0.112.2 uvicorn[standard]==0.30.6 SQLAlchemy==2.0.35 \
+                     pydantic==2.8.2 pydantic-settings==2.4.0 email-validator>=2.2.0 \
+                     'psycopg[binary]==3.2.10' alembic==1.13.2 python-multipart==0.0.9 pytest
       - name: Wait for Postgres
         run: |
           for i in {1..60}; do
@@ -50,6 +52,4 @@ jobs:
         run: alembic -c alembic.ini upgrade head
       - name: Run tests
         working-directory: backend
-        env:
-          PYTHONPATH: backend:.
         run: pytest -q tests

--- a/PS1/backend_tests.ps1
+++ b/PS1/backend_tests.ps1
@@ -1,21 +1,28 @@
 #!/usr/bin/env pwsh
 $ErrorActionPreference = "Stop"
 
+Write-Host "Running backend tests (host venv)..."
+
 # ensure venv
 if (-not (Test-Path ".venv")) { python -m venv .venv }
-. .\.venv\Scripts\Activate.ps1
+$venv = Join-Path (Get-Location) ".venv"
+$activate = Join-Path $venv "Scripts/Activate.ps1"
+. $activate
 python -m pip install -U pip
+
+# install dev deps
 if (Test-Path "backend/requirements-dev.txt") {
   pip install -r backend/requirements-dev.txt
 } else {
   pip install pytest httpx
 }
 
-# Use sqlite by default for local tests
+# default to sqlite for local tests
 if (-not $env:DATABASE_URL) { $env:DATABASE_URL = "sqlite:///./test.db" }
 
 Set-Location backend
 python -m pytest -q
+if ($LASTEXITCODE -ne 0) { throw "pytest failed with exit code $LASTEXITCODE" }
 
 Write-Host "Tests OK" -ForegroundColor Green
 

--- a/PS1/dev_bootstrap.ps1
+++ b/PS1/dev_bootstrap.ps1
@@ -16,7 +16,9 @@ $ErrorActionPreference = "Stop"
 
 # 1) venv
 if (-not (Test-Path ".venv")) { python -m venv .venv }
-. .\.venv\Scripts\Activate.ps1
+$venv = Join-Path (Get-Location) ".venv"
+$activate = Join-Path $venv "Scripts/Activate.ps1"
+. $activate
 python -m pip install -U pip
 
 # 2) deps
@@ -24,8 +26,9 @@ if (Test-Path "backend/requirements-dev.txt") {
   pip install -r backend/requirements-dev.txt
 } else {
   pip install fastapi==0.112.2 uvicorn[standard]==0.30.6 SQLAlchemy==2.0.35 `
-              pydantic==2.8.2 pydantic-settings==2.4.0 psycopg-binary==3.2.1 `
-              alembic==1.13.2 python-multipart==0.0.9 pytest httpx
+              pydantic==2.8.2 pydantic-settings==2.4.0 email-validator>=2.2.0 `
+              'psycopg[binary]==3.2.10' alembic==1.13.2 python-multipart==0.0.9 `
+              PyJWT==2.9.0 bcrypt==4.2.0 pytest httpx
 }
 
 # 3) DB URL (default to sqlite file)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,17 +3,27 @@ FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# System deps needed by healthcheck and psycopg
-RUN apt-get update && apt-get install -y --no-install-recommends libpq5 curl && rm -rf /var/lib/apt/lists/*
+# System deps needed by healthcheck (curl); psycopg[binary] bundles libpq
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app/backend
 
-# Install Python deps
-COPY backend/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
-
 # Copy backend sources
 COPY backend/ /app/backend/
+
+# Install Python deps (include email-validator and newer psycopg[binary])
+RUN pip install --no-cache-dir \
+    fastapi==0.112.2 \
+    uvicorn[standard]==0.30.6 \
+    SQLAlchemy==2.0.35 \
+    pydantic==2.8.2 \
+    pydantic-settings==2.4.0 \
+    email-validator>=2.2.0 \
+    'psycopg[binary]==3.2.10' \
+    alembic==1.13.2 \
+    python-multipart==0.0.9 \
+    PyJWT==2.9.0 \
+    bcrypt==4.2.0
 
 EXPOSE 8000
 CMD ["bash","-lc","./docker/entrypoint.sh"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,8 @@ uvicorn[standard]==0.30.6
 SQLAlchemy==2.0.35
 pydantic==2.8.2
 pydantic-settings==2.4.0
-psycopg[binary]==3.2.1
+email-validator>=2.2.0
+psycopg[binary]==3.2.10
 alembic==1.13.2
 python-multipart==0.0.9
 PyJWT==2.9.0


### PR DESCRIPTION
## Summary
- add email-validator dependency and bump psycopg[binary] to 3.2.10
- install explicit deps in backend workflow and Dockerfile
- improve dev/test PowerShell scripts and ensure pytest failures surface

## Testing
- `pytest -q`
- ⚠️ `pwsh -File PS1/dev_bootstrap.ps1` *(command not found)*
- ⚠️ `docker-compose -f docker-compose.yml -f docker-compose.dev.yml --profile dev up -d --build db api-dev` *(no docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bef95ec9ec8330a56ed95ccd8c0ce0