### PR TITLE
ci: install dev deps for backend tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -34,12 +34,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install dependencies
+      - name: Install dependencies (runtime + dev)
         run: |
           python -m pip install -U pip
-          pip install fastapi==0.112.2 uvicorn[standard]==0.30.6 SQLAlchemy==2.0.35 \
-                     pydantic==2.8.2 pydantic-settings==2.4.0 email-validator>=2.2.0 \
-                     'psycopg[binary]==3.2.10' alembic==1.13.2 python-multipart==0.0.9 pytest
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
       - name: Wait for Postgres
         run: |
           for i in {1..60}; do


### PR DESCRIPTION
## Summary
- ensure backend workflow installs runtime and dev requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68befe29e3b08330b76892eb6868afcc