### PR TITLE
Add HTTPX dependency and CI test setup

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,13 +28,12 @@ jobs:
       DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/orga
       APP_ENV: ci
       APP_DEBUG: 'false'
-      PYTHONPATH: backend:.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install dependencies (runtime + dev)
+      - name: Install backend deps
         run: |
           python -m pip install -U pip
           pip install -r backend/requirements.txt -r backend/requirements-dev.txt
@@ -49,5 +48,6 @@ jobs:
         working-directory: backend
         run: alembic -c alembic.ini upgrade head
       - name: Run tests
-        working-directory: backend
         run: pytest -q tests
+        env:
+          PYTHONPATH: backend:.

--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -1,17 +1,18 @@
 #!/usr/bin/env pwsh
 $ErrorActionPreference = "Stop"
 
-$Base = $env:SMOKE_BASE
-if (-not $Base) { $Base = "http://localhost:8000" }
+# Try a login request
+$Email = $env["SMOKE_EMAIL"]
+$Password = $env["SMOKE_PASSWORD"]
+if (-not $Email -or -not $Password) {
+  Write-Host "SMOKE_EMAIL/SMOKE_PASSWORD not set, skipping auth smoke"
+  exit 0
+}
 
-# Health
-$r = Invoke-RestMethod -Uri "$Base/health" -Method Get
-$r | ConvertTo-Json -Compress | Write-Output
-
-# Optional quick create if env present
-$Email = $env:SMOKE_EMAIL
-$Name  = $env:SMOKE_NAME
-if ($Email -and $Name) {
-  $body = @{ email = $Email; full_name = $Name } | ConvertTo-Json
-  Invoke-RestMethod -Uri "$Base/users" -Method Post -ContentType 'application/json' -Body $body | Out-Null
+try {
+  $resp = Invoke-RestMethod -Method Post -Uri "http://localhost:8000/auth/login" -ContentType "application/json" -Body (@{ email=$Email; password=$Password } | ConvertTo-Json)
+  if ($resp.access_token) { Write-Host "auth login OK"; exit 0 } else { Write-Error "no token"; exit 1 }
+} catch {
+  Write-Error $_
+  exit 1
 }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,22 +8,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 
 WORKDIR /app/backend
 
+# Install Python deps
+COPY backend/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
 # Copy backend sources
 COPY backend/ /app/backend/
-
-# Install Python deps (include email-validator and newer psycopg[binary])
-RUN pip install --no-cache-dir \
-    fastapi==0.112.2 \
-    uvicorn[standard]==0.30.6 \
-    SQLAlchemy==2.0.35 \
-    pydantic==2.8.2 \
-    pydantic-settings==2.4.0 \
-    email-validator>=2.2.0 \
-    'psycopg[binary]==3.2.10' \
-    alembic==1.13.2 \
-    python-multipart==0.0.9 \
-    PyJWT==2.9.0 \
-    bcrypt==4.2.0
 
 EXPOSE 8000
 CMD ["bash","-lc","./docker/entrypoint.sh"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,5 @@ python-multipart==0.0.9
 PyJWT==2.9.0
 bcrypt==4.2.0
 
+httpx==0.27.2
+

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,10 +1,11 @@
-import os
-import requests
+from fastapi.testclient import TestClient
+from app.main import app
 
-BASE = os.getenv("API_BASE", "http://localhost:8000")
+client = TestClient(app)
+
 
 def test_health():
-    r = requests.get(f"{BASE}/health", timeout=5)
+    r = client.get("/health")
     assert r.status_code == 200
     data = r.json()
     assert data.get("status") == "ok"


### PR DESCRIPTION
## Summary
- install HTTPX alongside existing backend deps
- ensure Docker image and CI workflow install backend requirements
- add login smoke test script and in-process health test

## Testing
- `pip install -r backend/requirements.txt -r backend/requirements-dev.txt`
- `PYTHONPATH=backend:. pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a91fcec833096e4c8df1e7ebb88